### PR TITLE
Added a workaround comment in JSON.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,7 @@
 {
     "development": {
       "username": "root",
+      "**--COMMENT--**": "ENTER YOUR MySQL PASSWORD BELOW.",
       "password": "",
       "database": "emflcDB",
       "host": "127.0.0.1",


### PR DESCRIPTION
Since JSON doesn't allow commenting, there is a workaround were you can include a comment as data. I've added one above the password entry data as an instruction to include the user's personal MySQL password."